### PR TITLE
Correccion al mostrar mensaje.

### DIFF
--- a/Cliente/El_Camello/Vistas/Aspirante/Mensajeria.xaml.cs
+++ b/Cliente/El_Camello/Vistas/Aspirante/Mensajeria.xaml.cs
@@ -93,7 +93,10 @@ namespace El_Camello.Vistas.Aspirante
                     contenidoMensaje, 
                     perfilAspirante.Token);
                 txtMensaje.Text = "";
-                MostrarMensaje(mensaje);
+                if (mensaje.IdMensaje > 0)
+                {
+                    MostrarMensaje(mensaje);
+                }
             }
         }
     }

--- a/Cliente/El_Camello/Vistas/Demandante/Mensajeria.xaml.cs
+++ b/Cliente/El_Camello/Vistas/Demandante/Mensajeria.xaml.cs
@@ -91,7 +91,10 @@ namespace El_Camello.Vistas.Demandante
                     contenidoMensaje,
                     perfilDemandante.Token);
                 txtMensaje.Text = "";
-                MostrarMensaje(mensaje);
+                if(mensaje.IdMensaje > 0)
+                {
+                    MostrarMensaje(mensaje);
+                }
             }
         }
     }


### PR DESCRIPTION
Si el mensaje no se envia el metodo DAO regresa un objeto mensaje con idMensaje igual a cero. Por lo que se valida que el id sea mayor a cero para mostrarlo en pantalla.